### PR TITLE
😎 한혜성_알고리즘문제풀이

### DIFF
--- a/HHS/221018_한혜성_연속합.java
+++ b/HHS/221018_한혜성_연속합.java
@@ -1,0 +1,40 @@
+import java.io.*;
+import java.util.*;
+
+public class Main_BOJ_1912_연속합 {
+
+	static int N;
+	static int[] dp;
+	static int[] input;
+	static int Max;
+	
+	public static void main(String[] args) throws IOException{
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		N = Integer.parseInt(br.readLine());
+		
+		String [] str = br.readLine().split(" ");
+		dp = new int[N];
+		input = new int[N];
+
+		for(int i = 0; i < N; i++) {
+			input[i] = Integer.parseInt(str[i]);
+		}
+		
+		Max = input[0];
+		dp[0] = input[0];
+		for(int i = 1; i < N; i++) {
+			dp[i] = Math.max(dp[i-1]+ input[i], input[i]);
+			Max = Math.max(dp[i], Max);
+		}
+		
+		bw.write(String.valueOf(Max));
+		bw.close();
+		
+	}
+
+	
+
+}


### PR DESCRIPTION
**- 연속합**
- dp로 이차원배열을 만들어서 [N][N]사이즈로 해서 계산했더니 메모리초과가 나서 [2][N]으로도 해봤는데 이번엔 시간초과가 나서
 다 뒤집어엎었다.
- 전 인덱스와 자신을 더한 값(dp[i-1]+arr[i])과 자신의 값(arr[i])만 비교해서 돌려주면 되는데 너무 어렵게 생각했던 것 같다.
- 실버2인듯 아닌듯 맞는 문제...